### PR TITLE
Add new hugo theme which support Waline by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ List of themes that support Waline by default.
 
 - [hugo-theme-stack](https://github.com/CaiJimmy/hugo-theme-stack)
 - [DoIt](https://github.com/HEIGE-PCloud/DoIt)
+- [hugo-theme-next](https://github.com/hugo-next/hugo-theme-next)
 
 ## Tools
 


### PR DESCRIPTION
Hugo NexT theme were support Waline comment plugin by default as major.